### PR TITLE
Remove free() from prunning function

### DIFF
--- a/screenkey-guard.c
+++ b/screenkey-guard.c
@@ -56,7 +56,6 @@ bool prunning(const char* program) {
         }
         fclose(status);
     }
-    free(dirent);
     closedir(proc);
     return 0;
 }


### PR DESCRIPTION
on `man 3 readdir`:
> On success, readdir() returns a pointer to a dirent structure.  (This structure may be statically allocated; do not attempt to free(3) it.)